### PR TITLE
Attempts to fix 404 page creation for this plate.

### DIFF
--- a/views/404-page.tpl
+++ b/views/404-page.tpl
@@ -1,0 +1,9 @@
+(** this is your 404 page when a bad page is reached **)
+<h1>404 Page Not Found</h1>
+
+(** google code **)
+<script type="text/javascript">
+    var GOOG_FIXURL_LANG = 'en';
+    var GOOG_FIXURL_SITE = '';
+</script>
+<script type="text/javascript" src="http://linkhelp.clients.google.com/tbproxy/lh/wm/fixurl.js"></script>

--- a/views/404.tpl
+++ b/views/404.tpl
@@ -1,9 +1,0 @@
-(** this is your 404 page when a bad page is reached **)
-<h1>404 Page Not Found</h1>
-
-(** google code **)
-<script type="text/javascript">
-    var GOOG_FIXURL_LANG = 'en';
-    var GOOG_FIXURL_SITE = '';
-</script>
-<script type="text/javascript" src="http://linkhelp.clients.google.com/tbproxy/lh/wm/fixurl.js"></script>


### PR DESCRIPTION
This adds a `404-page.tpl` file as @dustinhorning noted that this plate lacks one, and that `404.tpl` doesn't work.   Also removes existing `404.tpl` which doesn't get built by the plate creator in either zid or zuid zesty.